### PR TITLE
Zabbix API datasource and UI elements.

### DIFF
--- a/datasources/zabbix/annotation_editor.html
+++ b/datasources/zabbix/annotation_editor.html
@@ -1,5 +1,8 @@
 <div class="editor-row">
-  <div class="section">
-    Events derived from selected items.
-  </div>
+	<div class="section">
+		<h5>Item ids <tip>Example: 123, 45, 678</tip></h5>
+		<div class="editor-option">
+			<input type="text" class="span10" ng-model='currentAnnotation.aids' placeholder="###, ###, ##"></input>
+		</div>
+	</div>
 </div>

--- a/datasources/zabbix/annotation_editor.html
+++ b/datasources/zabbix/annotation_editor.html
@@ -1,0 +1,5 @@
+<div class="editor-row">
+  <div class="section">
+    Events derived from selected items.
+  </div>
+</div>

--- a/datasources/zabbix/editor.html
+++ b/datasources/zabbix/editor.html
@@ -1,0 +1,73 @@
+
+<div class="editor-row">
+    <div  ng-repeat="target in panel.targets"
+         class="grafana-target"
+         ng-class="{'grafana-target-hidden': target.hide}"
+         ng-controller="ZabbixAPITargetCtrl"
+         ng-init="init()">
+
+    <div class="grafana-target-inner">
+        <ul class="grafana-target-controls">
+            <li class="dropdown">
+                <a  class="pointer dropdown-toggle"
+                    data-toggle="dropdown"
+                    tabindex="1">
+                    <i class="icon-cog"></i>
+                </a>
+                <ul class="dropdown-menu pull-right" role="menu">
+                    <li role="menuitem">
+                        <a  tabindex="1"
+                            ng-click="duplicate()">
+                            Duplicate
+                        </a>
+                    </li>
+                    <li role="menuitem">
+                        <a  tabindex="1"
+                            ng-click="moveMetricQuery($index, $index-1)">
+                            Move up
+                        </a>
+                    </li>
+                    <li role="menuitem">
+                        <a  tabindex="1"
+                            ng-click="moveMetricQuery($index, $index+1)">
+                            Move down
+                        </a>
+                    </li>
+                </ul>
+            </li>
+            <li>
+                <a class="pointer" tabindex="1" ng-click="removeDataQuery(target)">
+                    <i class="icon-remove"></i>
+                </a>
+            </li>
+        </ul>
+
+        <ul class="grafana-segment-list">
+            <li class="grafana-target-segment" style="min-width: 15px; text-align: center">
+                {{targetLetters[$index]}}
+            </li>
+            <li>
+                <a  class="grafana-target-segment"
+                    ng-click="target.hide = !target.hide; targetBlur();"
+                    role="menuitem">
+                    <i class="icon-eye-open"></i>
+                </a>
+            </li>
+        </ul>
+
+        <ul class="grafana-segment-list" role="menu">
+            <li>
+                <input type="text" class="input-medium grafana-target-text-input" ng-model="target.alias"
+                       spellcheck='false' placeholder="alias" ng-blur="targetBlur()">
+            </li>
+            <li>
+                <input type="text" class="input-medium grafana-target-text-input" ng-model="target.itemid"
+                       spellcheck='false' placeholder="Item id" ng-blur="targetBlur()">
+            </li>
+        </ul>
+
+        <div class="clearfix"></div>
+
+    </div>
+    </div>
+</div>

--- a/datasources/zabbix/zabbix.js
+++ b/datasources/zabbix/zabbix.js
@@ -27,12 +27,12 @@ function (angular, _, kbn) {
       // get from & to in seconds
       var from = kbn.parseDate(options.range.from).getTime();
       var to = kbn.parseDate(options.range.to).getTime();
-      var items = _.pluck(options.targets, 'itemid');
+      var items = _.indexBy(options.targets, 'itemid')
 
       from = Math.ceil(from/1000);
       to = Math.ceil(to/1000);
 
-      return this.performTimeSeriesQuery(items, from, to)
+      return this.performTimeSeriesQuery(_.keys(items), from, to)
         .then(_.bind(function (response) {
 
           // Response should be in the format:
@@ -49,8 +49,8 @@ function (angular, _, kbn) {
                 //  normalize to Grafana response format.
                 function (i, id) {
                   return {
-                    // TODO unroll return with itemid:alias map
-                    target: id,
+                    // Lookup itemid:alias map
+                    target: items[id].alias,
                     datapoints: _.map(i, function (p) { return [p.value, p.clock*1000];})
                   };
               })

--- a/datasources/zabbix/zabbix.js
+++ b/datasources/zabbix/zabbix.js
@@ -1,0 +1,74 @@
+define([
+  'angular',
+  'lodash',
+  'kbn',
+  'moment'
+],
+function (angular, _, kbn) {
+  'use strict';
+
+  var module = angular.module('grafana.services');
+
+  module.factory('ZabbixAPIDatasource', function($q, $http, templateSrv) {
+    function ZabbixAPIDatasource(datasource) {
+      this.name             = datasource.name;
+      this.type             = 'ZabbixAPIDatasource';
+      this.supportMetrics   = true;
+      this.url              = datasource.url;
+      this.auth             = datasource.auth;
+      // TODO user/pass auth to get token
+
+      this.partials = datasource.partials || 'plugins/grafana-plugins/datasources/zabbix';
+      this.editorSrc = this.partials + '/editor.html';
+    }
+
+
+    ZabbixAPIDatasource.prototype.query = function(options) {
+      // get from & to in seconds
+      var from = kbn.parseDate(options.range.from).getTime();
+      var to = kbn.parseDate(options.range.to).getTime();
+      var queries = ""; // Derive from: options.targets, look at: convertTargetToQuery
+
+      from = Math.ceil(from/1000);
+      to = Math.ceil(to/1000);
+
+      return this.performTimeSeriesQuery(queries, from, to)
+        .then(_.bind(function (response) {
+          return {data: [{datapoints: _.map(response.data.result, function (p) { return [p.value, p.clock*1000];}), target: "I1"}]};
+        },options));
+    };
+
+    ZabbixAPIDatasource.prototype.performTimeSeriesQuery = function(queries, start, end) {
+      var reqBody = {
+        jsonrpc: '2.0',
+        method: 'history.get',
+        params: {
+            output: 'extend',
+            history: 0,
+            itemids: 683,
+            sortfield: 'clock',
+            sortorder: 'DESC',
+            limit: 1000,
+            time_from: start,
+        },
+        auth: this.auth,
+        id: 1
+      };
+
+      // Relative queries (e.g. last hour) don't include an end time
+      if (end) {
+        reqBody.params.time_till = end;
+      }
+
+      var options = {
+        method: 'POST',
+        url: this.url + '',
+        data: reqBody
+      };
+
+      return $http(options);
+    };
+
+    return ZabbixAPIDatasource;
+  });
+});

--- a/datasources/zabbix/zabbix.js
+++ b/datasources/zabbix/zabbix.js
@@ -17,6 +17,7 @@ function (angular, _, kbn) {
       this.url              = datasource.url;
       this.auth             = datasource.auth;
       // TODO user/pass auth to get token
+      this.limitmetrics     = datasource.limitmetrics || 5000;
 
       this.partials = datasource.partials || 'plugins/grafana-plugins/datasources/zabbix';
       this.editorSrc = this.partials + '/editor.html';
@@ -71,7 +72,7 @@ function (angular, _, kbn) {
               itemids: items,
               sortfield: 'clock',
               sortorder: 'DESC',
-              limit: 1000, // Where do he defaults for this come from?
+              limit: this.limitmetrics,
               time_from: start,
           },
           auth: this.auth,

--- a/datasources/zabbix/zabbix.js
+++ b/datasources/zabbix/zabbix.js
@@ -27,44 +27,61 @@ function (angular, _, kbn) {
       // get from & to in seconds
       var from = kbn.parseDate(options.range.from).getTime();
       var to = kbn.parseDate(options.range.to).getTime();
-      var queries = ""; // Derive from: options.targets, look at: convertTargetToQuery
+      var items = _.pluck(options.targets, 'itemid');
 
       from = Math.ceil(from/1000);
       to = Math.ceil(to/1000);
 
-      return this.performTimeSeriesQuery(queries, from, to)
+      return this.performTimeSeriesQuery(items, from, to)
         .then(_.bind(function (response) {
-          return {data: [{datapoints: _.map(response.data.result, function (p) { return [p.value, p.clock*1000];}), target: "I1"}]};
+
+          // Response should be in the format:
+          //[{
+          //  target: "Metric name",
+          //  datapoints: [[<value>, <unixtime>], ...]
+          //},]
+
+          return {
+            data: _.map(
+              // Index returned datapoints by item/metric id
+              _.groupBy(response.data.result, function (p) { return p.itemid }),
+                // Foreach itemid index: iterate over the data points and
+                //  normalize to Grafana response format.
+                function (i, id) {
+                  return {
+                    // TODO unroll return with itemid:alias map
+                    target: id,
+                    datapoints: _.map(i, function (p) { return [p.value, p.clock*1000];})
+                  };
+              })
+          };
         },options));
     };
 
-    ZabbixAPIDatasource.prototype.performTimeSeriesQuery = function(queries, start, end) {
-      var reqBody = {
-        jsonrpc: '2.0',
-        method: 'history.get',
-        params: {
-            output: 'extend',
-            history: 0,
-            itemids: 683,
-            sortfield: 'clock',
-            sortorder: 'DESC',
-            limit: 1000,
-            time_from: start,
-        },
-        auth: this.auth,
-        id: 1
-      };
-
-      // Relative queries (e.g. last hour) don't include an end time
-      if (end) {
-        reqBody.params.time_till = end;
-      }
-
+    ZabbixAPIDatasource.prototype.performTimeSeriesQuery = function(items, start, end) {
       var options = {
         method: 'POST',
         url: this.url + '',
-        data: reqBody
+        data: {
+          jsonrpc: '2.0',
+          method: 'history.get',
+          params: {
+              output: 'extend',
+              history: 0, // TODO this needs to be exposed
+              itemids: items,
+              sortfield: 'clock',
+              sortorder: 'DESC',
+              limit: 1000, // Where do he defaults for this come from?
+              time_from: start,
+          },
+          auth: this.auth,
+          id: 1
+        },
       };
+      // Relative queries (e.g. last hour) don't include an end time
+      if (end) {
+        options.data.params.time_till = end;
+      }
 
       return $http(options);
     };

--- a/datasources/zabbix/zabbixTargetCtrl.js
+++ b/datasources/zabbix/zabbixTargetCtrl.js
@@ -1,0 +1,45 @@
+define([
+  'angular',
+  'lodash'
+],
+function (angular, _) {
+  'use strict';
+
+  var module = angular.module('grafana.controllers');
+
+  module.controller('ZabbixAPITargetCtrl', function($scope) {
+
+    $scope.init = function() {
+      $scope.target.errors = validateTarget($scope.target);
+    };
+
+    $scope.targetBlur = function() {
+      $scope.target.errors = validateTarget($scope.target);
+      if (!_.isEqual($scope.oldTarget, $scope.target) && _.isEmpty($scope.target.errors)) {
+        $scope.oldTarget = angular.copy($scope.target);
+        $scope.get_data();
+      }
+    };
+
+    $scope.duplicate = function() {
+      var clone = angular.copy($scope.target);
+      $scope.panel.targets.push(clone);
+    };
+    $scope.moveMetricQuery = function(fromIndex, toIndex) {
+      _.move($scope.panel.targets, fromIndex, toIndex);
+    };
+
+
+    //////////////////////////////
+    // VALIDATION
+    //////////////////////////////
+
+    function validateTarget(target) {
+      var errs = {};
+
+      return errs;
+    }
+
+  });
+
+});


### PR DESCRIPTION
This builds off the work by @nucleusv and uses the Grafana UI context to query
history of specific itemids (with the goal that later the lookups for metric
key or other contexts can be performed from the API as well).

xref: #8, grafana/grafana#1291, grafana/grafana#147

---

![screenshot 2015-03-27 at 2 01 55 am](https://cloud.githubusercontent.com/assets/65640/6863837/6449391a-d426-11e4-9d55-7af8c9dfd9bf.png)

(note - the Zabbix public demo server can be used for testing, e.g. http://zabbix.org/zabbix/history.php?action=showgraph&itemids[]=683 )

example config info:

```js
...
      datasources: {
          Zabbix: {
            type: 'ZabbixAPIDatasource',
            url: 'http://zabbix.org/zabbix/api_jsonrpc.php',
            auth: 'f2c3a81a739087e9e0b55e821610c26b',
          },
      },
...
```