### PR TITLE
Implemented metricFindQuery() to enable templating by query for prometheus

### DIFF
--- a/datasources/prometheus/datasource.js
+++ b/datasources/prometheus/datasource.js
@@ -112,6 +112,25 @@ function (angular, _, kbn) {
       });
     };
 
+    PrometheusDatasource.prototype.metricFindQuery = function(query) {
+      var url = this.url + '/api/query?expr=' + encodeURIComponent(query)
+
+      var options = {
+        method: 'GET',
+        url: url,
+      };
+
+      return $http(options)
+        .then(function(result) {
+          return _.map(result.data.value, function(metric) {
+            return {
+              text: _.values(metric.metric),
+              expandable: true
+            };
+          });
+        });
+    };
+
     function transformMetricData(md, options) {
       var dps = [],
           metricLabel = null;


### PR DESCRIPTION
This is the initial implementation of metricFindQuery for templating.
Prometheus API has no endpoint to query tag names/values yet and I tried to make it as generic as possible so others can use it too.
I use it like this to create a query template which returns all instances:
```
sum(up{job="s3", group="slave"}) by (instance)
```
I'm not sure if this is a correct implementation.
Also as I checked other plugins I found out that this function handles some other stuff too but it was not clear, it would be nice if someone could clarify it or point me to the documentation.
