### PR TITLE
Add Prometheus step resolution option

### DIFF
--- a/datasources/prometheus/datasource.js
+++ b/datasources/prometheus/datasource.js
@@ -42,11 +42,7 @@ function (angular, _, kbn) {
 
         var interval = target.interval || options.interval;
         var intervalFactor = target.intervalFactor || 1;
-        var step = this.calculateInterval(interval, intervalFactor);
-        if (step < 1) {
-          step = 1; // lowest step is 1 second
-        }
-        query.step = step;
+        query.step = this.calculateInterval(interval, intervalFactor);
 
         queries.push(query);
       }, this));

--- a/datasources/prometheus/datasource.js
+++ b/datasources/prometheus/datasource.js
@@ -40,11 +40,11 @@ function (angular, _, kbn) {
         var query = {};
         query.expr = templateSrv.replace(target.expr);
 
-        var maxDataPoints = parseInt(target.maxDataPoints || options.maxDataPoints, 10);
-        if (_.isNaN(maxDataPoints)) {
-          throw "max data points is not number";
+        var step = kbn.interval_to_seconds(target.interval || options.interval);
+        if (step < 1) {
+          step = 1; // lowest step is 1 second
         }
-        query.maxDataPoints = maxDataPoints;
+        query.step = step;
 
         queries.push(query);
       });
@@ -81,7 +81,7 @@ function (angular, _, kbn) {
     PrometheusDatasource.prototype.performTimeSeriesQuery = function(query, range, end) {
       var url = this.url + '/api/query_range?expr=' + encodeURIComponent(query.expr) + '&range=' + range + '&end=' + end;
 
-      var step = Math.ceil(range / query.maxDataPoints);
+      var step = query.step;
       // Prometheus drop query if range/step > 11000
       // calibrate step if it is too big
       if (step !== 0 && range / step > 11000) {

--- a/datasources/prometheus/datasource.js
+++ b/datasources/prometheus/datasource.js
@@ -65,7 +65,7 @@ function (angular, _, kbn) {
           var result = [];
 
           _.each(allResponse, function(response, index) {
-            if (response.data.type === "error") {
+            if (response.data.type === 'error') {
               throw response.data.value;
             }
 
@@ -113,7 +113,7 @@ function (angular, _, kbn) {
     };
 
     PrometheusDatasource.prototype.metricFindQuery = function(query) {
-      var url = this.url + '/api/query?expr=' + encodeURIComponent(query)
+      var url = this.url + '/api/query?expr=' + encodeURIComponent(query);
 
       var options = {
         method: 'GET',

--- a/datasources/prometheus/partials/query.editor.html
+++ b/datasources/prometheus/partials/query.editor.html
@@ -134,7 +134,7 @@
         </li>
         <li>
           <input type="text"
-                 class="input-small tight-form-input"
+                 class="input-mini tight-form-input"
                  ng-model="target.interval"
                  bs-tooltip="'Leave blank for auto handling based on time range and panel width'"
                  data-placement="right"
@@ -151,7 +151,7 @@
         </li>
         <li>
           <select ng-model="target.intervalFactor"
-                 class="tight-form-input input-small"
+                 class="tight-form-input input-mini"
                  ng-options="r.factor as r.label for r in resolutions"
                  ng-change="refreshMetricData()">
           </select>

--- a/datasources/prometheus/partials/query.editor.html
+++ b/datasources/prometheus/partials/query.editor.html
@@ -158,7 +158,7 @@
         </li>
 
         <li class="tight-form-item">
-          <a href="{{target.prometheus_link}}" target="_blank" bs-tooltip="'Link to Graph in Prometheus'">
+          <a href="{{target.prometheusLink}}" target="_blank" bs-tooltip="'Link to Graph in Prometheus'">
             <i class="fa fa-share-square-o"></i>
           </a>
         </li>

--- a/datasources/prometheus/partials/query.editor.html
+++ b/datasources/prometheus/partials/query.editor.html
@@ -130,16 +130,16 @@
         </li>
 
         <li class="tight-form-item" style="width: 100px">
-          Max points
+          Step
         </li>
         <li>
           <input type="text"
                  class="input-small tight-form-input"
-                 ng-model="target.maxDataPoints"
-                 bs-tooltip="'Override max data points, automatically set to graph width in pixels.'"
+                 ng-model="target.interval"
+                 bs-tooltip="'Leave blank for auto handling based on time range and panel width'"
                  data-placement="right"
                  spellcheck='false'
-                 placeholder="auto"
+                 placeholder="{{target.calculated_interval}}"
                  data-min-length=0 data-items=100
                  ng-model-onblur
                  ng-change="refreshMetricData()"

--- a/datasources/prometheus/partials/query.editor.html
+++ b/datasources/prometheus/partials/query.editor.html
@@ -139,11 +139,22 @@
                  bs-tooltip="'Leave blank for auto handling based on time range and panel width'"
                  data-placement="right"
                  spellcheck='false'
-                 placeholder="{{target.calculated_interval}}"
+                 placeholder="{{target.calculatedInterval}}"
                  data-min-length=0 data-items=100
                  ng-model-onblur
                  ng-change="refreshMetricData()"
                  />
+        </li>
+
+        <li class="tight-form-item">
+          Resolution
+        </li>
+        <li>
+          <select ng-model="target.intervalFactor"
+                 class="tight-form-input input-small"
+                 ng-options="r.factor as r.label for r in resolutions"
+                 ng-change="refreshMetricData()">
+          </select>
         </li>
 
         <li class="tight-form-item">

--- a/datasources/prometheus/queryCtrl.js
+++ b/datasources/prometheus/queryCtrl.js
@@ -18,6 +18,7 @@ function (angular, _, kbn) {
       }
       $scope.target.metric = "";
       $scope.target.prometheus_link = $scope.linkToPrometheus();
+      $scope.target.calculated_interval = calculateInterval($scope.interval);
 
       $scope.$on('typeahead-updated', function() {
         $scope.$apply($scope.inputMetric);
@@ -28,6 +29,7 @@ function (angular, _, kbn) {
     $scope.refreshMetricData = function() {
       $scope.target.errors = validateTarget($scope.target);
       $scope.target.prometheus_link = $scope.linkToPrometheus();
+      $scope.target.calculated_interval = calculateInterval($scope.interval);
 
       // this does not work so good
       if (!_.isEqual($scope.oldTarget, $scope.target) && _.isEmpty($scope.target.errors)) {
@@ -98,6 +100,16 @@ function (angular, _, kbn) {
       var errs = {};
 
       return errs;
+    }
+
+    function calculateInterval(interval) {
+      var sec = kbn.interval_to_seconds(interval);
+
+      if (sec < 1) {
+        interval = '1s';
+      }
+
+      return interval;
     }
 
   });

--- a/datasources/prometheus/queryCtrl.js
+++ b/datasources/prometheus/queryCtrl.js
@@ -14,10 +14,10 @@ function (angular, _, kbn) {
       $scope.target.errors = validateTarget();
 
       if (!$scope.target.expr) {
-        $scope.target.expr = "";
+        $scope.target.expr = '';
       }
-      $scope.target.metric = "";
-      $scope.target.prometheus_link = $scope.linkToPrometheus();
+      $scope.target.metric = '';
+      $scope.target.prometheusLink = $scope.linkToPrometheus();
 
       $scope.resolutions = [
         { factor:  1, },
@@ -47,7 +47,7 @@ function (angular, _, kbn) {
 
     $scope.refreshMetricData = function() {
       $scope.target.errors = validateTarget($scope.target);
-      $scope.target.prometheus_link = $scope.linkToPrometheus();
+      $scope.target.prometheusLink = $scope.linkToPrometheus();
       $scope.calculateInterval();
 
       // this does not work so good
@@ -59,7 +59,7 @@ function (angular, _, kbn) {
 
     $scope.inputMetric = function() {
       $scope.target.expr += $scope.target.metric;
-      $scope.target.metric = "";
+      $scope.target.metric = '';
     };
 
     $scope.moveMetricQuery = function(fromIndex, toIndex) {

--- a/datasources/prometheus/queryCtrl.js
+++ b/datasources/prometheus/queryCtrl.js
@@ -17,7 +17,6 @@ function (angular, _, kbn) {
         $scope.target.expr = '';
       }
       $scope.target.metric = '';
-      $scope.target.prometheusLink = $scope.linkToPrometheus();
 
       $scope.resolutions = [
         { factor:  1, },
@@ -38,6 +37,7 @@ function (angular, _, kbn) {
       $scope.$on('render', function() {
         $scope.calculateInterval(); // re-calculate interval when time range is updated
       });
+      $scope.target.prometheusLink = $scope.linkToPrometheus();
 
       $scope.$on('typeahead-updated', function() {
         $scope.$apply($scope.inputMetric);
@@ -47,8 +47,8 @@ function (angular, _, kbn) {
 
     $scope.refreshMetricData = function() {
       $scope.target.errors = validateTarget($scope.target);
-      $scope.target.prometheusLink = $scope.linkToPrometheus();
       $scope.calculateInterval();
+      $scope.target.prometheusLink = $scope.linkToPrometheus();
 
       // this does not work so good
       if (!_.isEqual($scope.oldTarget, $scope.target) && _.isEmpty($scope.target.errors)) {
@@ -94,8 +94,7 @@ function (angular, _, kbn) {
       var d = new Date(to);
       var endTime = [d.getFullYear(), d.getMonth() + 1, d.getDate()].join('-') + ' ' + d.getUTCHours() + ':' + d.getUTCMinutes();
 
-      var maxDataPoints = $scope.target.maxDataPoints || $scope.resolution;
-      var step = Math.ceil(range / maxDataPoints);
+      var step = kbn.interval_to_seconds(this.target.calculatedInterval);
       if (step !== 0 && range / step > 11000) {
         step = Math.floor(range / 11000);
       }


### PR DESCRIPTION
I notice that InfluxDB datasource plugin doesn't refer "maxDataPoints", it refers "interval" to calculate time range of query.
The "interval" is almost same as "step" of Prometheus, so "interval" is suitable for Prometheus, I changed to use it.
And, I add resolution option to suppress load of query.

![prometheus_step_resolution](https://cloud.githubusercontent.com/assets/224552/7449816/6bfcb7de-f278-11e4-9aea-eab98b496670.png)
