### PR TITLE
cloudera manager datasource (tsquery)

### DIFF
--- a/datasources/clouderamanager/datasource.js
+++ b/datasources/clouderamanager/datasource.js
@@ -1,0 +1,142 @@
+define([
+  'angular',
+  'lodash',
+  'jquery',
+  'config',
+  'app/core/utils/datemath',
+  'moment',
+  './directives',
+  './query_ctrl',
+],
+function (angular, _, $, config, dateMath, moment) {
+  'use strict';
+
+  var module = angular.module('grafana.services');
+
+  module.factory('ClouderaManagerDatasource', function($q, backendSrv) {
+    function ClouderaManagerDatasource(datasource) {
+      this.url = datasource.url;
+      if (this.url.endsWith('/')) {
+        this.url = this.url.substr(0, this.url.length - 1);
+      }
+      this.basicAuth = datasource.basicAuth;
+      this.withCredentials = datasource.withCredentials;
+      this.name = datasource.name;
+    }
+
+    // Helper to make API requests to Cloudera Manager. To avoid CORS issues, the requests may be proxied
+    // through Grafana's backend via `backendSrv.datasourceRequest`.
+    ClouderaManagerDatasource.prototype._request = function(options) {
+      options.url = this.url + options.url;
+      options.method = options.method || 'GET';
+      options.inspect = { 'type': 'cloudera_manager' };
+
+      if (this.basicAuth) {
+        options.withCredentials = true;
+        options.headers = {
+          "Authorization": this.basicAuth
+        };
+      }
+
+      return backendSrv.datasourceRequest(options);
+    };
+
+    // Test the connection to Cloudera Manager by querying for the supported API version.
+    ClouderaManagerDatasource.prototype.testDatasource = function() {
+      var options = {
+        url: '/api/version',
+        transformResponse: function(data) {
+          return data;
+        }
+      };
+
+      return this._request(options).then(function(response) {
+        return {
+          status: "success",
+          message: "Data source is working. API version is '" + response.data + "'.",
+          title: "Success"
+        };
+      });
+    };
+
+    // Query for metric targets within the specified time range.
+    // Returns the promise of a result dictionary. See the convertResponse comment
+    // for specifics of the result dictionary.
+    ClouderaManagerDatasource.prototype.query = function(queryOptions) {
+      var self = this;
+
+      var targetPromises = _(queryOptions.targets)
+        .filter(function(target) { return target.target && !target.hide; })
+        .map(function(target) {
+          var requestOptions = {
+            url: '/api/v10/timeseries',
+            params: {
+              query: target.target,
+              from: queryOptions.range.from.toJSON(),
+              to: queryOptions.range.to.toJSON(),
+              contentType: 'application/json',
+            }
+          };
+          return self._request(requestOptions).then(self.convertResponse);
+        })
+        .value();
+
+      return $q.all(targetPromises).then(function(convertedResponses) {
+        var result = {
+          data: _.map(convertedResponses, function(convertedResponse) {
+            return convertedResponse.data;
+          })
+        };
+        result.data = _.flatten(result.data);
+        return result;
+      });
+    };
+
+    // Convert the Cloudera Manager response to the format expected by Grafana.
+    //
+    // Grafana generally expects:
+    // { data: [
+    //   { target: 'metricName1',
+    //     datapoints: [ [a1, ts-a1], [a2, ts-a2], [a3, ts-a3] ]
+    //   },
+    //   { target: 'metricName2',
+    //     datapoints: [ [b1, ts-b1], [b2, ts-b2], [c3, ts-b3] ]
+    //   },
+    // ]}
+    //
+    // The CM API response has the general form:
+    // items: {
+    //   timeSeries: [
+    //     {
+    //       metadata: {
+    //         metricName: "metricName1",
+    //       },
+    //       timeSeries: {
+    //         value: 45.1234,
+    //         timestamp: "2015-10-02T12:58:24.009Z",
+    //       }
+    //     }
+    //   ]
+    // }
+    ClouderaManagerDatasource.prototype.convertResponse = function(response) {
+      if (!response || !response.data || !response.data.items) { return []; }
+
+      var seriesList = [];
+      _(response.data.items).forEach(function(item) {
+        _.forEach(item.timeSeries, function(timeSeries) {
+          seriesList.push({
+            target: timeSeries.metadata.metricName,
+            datapoints: _.map(timeSeries.data, function(point) {
+              var ts = moment.utc(dateMath.parse(point.timestamp)).unix() * 1000;
+              return [point.value, ts];
+            })
+          });
+        });
+      });
+
+      return {data: seriesList};
+    };
+
+    return ClouderaManagerDatasource;
+  });
+});

--- a/datasources/clouderamanager/directives.js
+++ b/datasources/clouderamanager/directives.js
@@ -1,0 +1,17 @@
+define([
+  'angular',
+],
+function (angular) {
+  'use strict';
+
+  var module = angular.module('grafana.directives');
+
+  module.directive('metricQueryEditorClouderamanager', function() {
+    return {controller: 'ClouderaManagerQueryCtrl', templateUrl: 'app/plugins/datasource/clouderamanager/partials/query.editor.html'};
+  });
+
+  module.directive('metricQueryOptionsClouderamanager', function() {
+    return {templateUrl: 'app/plugins/datasource/clouderamanager/partials/query.options.html'};
+  });
+
+});

--- a/datasources/clouderamanager/partials/config.html
+++ b/datasources/clouderamanager/partials/config.html
@@ -1,0 +1,1 @@
+<div ng-include="httpConfigPartialSrc"></div>

--- a/datasources/clouderamanager/partials/query.editor.html
+++ b/datasources/clouderamanager/partials/query.editor.html
@@ -1,0 +1,60 @@
+<div class="tight-form">
+	<ul class="tight-form-list pull-right">
+		<li ng-show="parserError" class="tight-form-item">
+			<a bs-tooltip="parserError" style="color: rgb(229, 189, 28)" role="menuitem">
+				<i class="fa fa-warning"></i>
+			</a>
+		</li>
+
+		<li class="tight-form-item small" ng-show="target.datasource">
+			<em>{{target.datasource}}</em>
+		</li>
+
+		<li class="tight-form-item">
+			<div class="dropdown">
+				<a class="pointer dropdown-toggle" data-toggle="dropdown" tabindex="1">
+					<i class="fa fa-bars"></i>
+				</a>
+				<ul class="dropdown-menu pull-right" role="menu">
+					<li role="menuitem">
+						<a tabindex="1" ng-click="duplicateDataQuery(target)">Duplicate</a>
+					</li>
+					<li role="menuitem">
+						<a tabindex="1" ng-click="moveDataQuery($index, $index-1)">Move up</a>
+					</li>
+					<li role="menuitem">
+						<a tabindex="1" ng-click="moveDataQuery($index, $index+1)">Move down</a>
+					</li>
+				</ul>
+			</div>
+		</li>
+		
+		<li class="tight-form-item last">
+			<a class="pointer" tabindex="1" ng-click="removeDataQuery(target)">
+				<i class="fa fa-remove"></i>
+			</a>
+		</li>
+	</ul>
+
+	<ul class="tight-form-list">
+		<li class="tight-form-item" style="min-width: 15px; text-align: center">
+			{{target.refId}}
+		</li>
+		<li>
+			<a class="tight-form-item" ng-click="target.hide = !target.hide; get_data();" role="menuitem">
+				<i class="fa fa-eye"></i>
+			</a>
+		</li>
+	</ul>
+
+	<input type="text"
+	       class="tight-form-clear-input span10"
+	       ng-model="target.target"
+	       spellcheck='false' 
+	       ng-model-onblur
+	       ng-change="get_data()"
+    ></input>
+
+	<div class="clearfix"></div>
+
+</div>

--- a/datasources/clouderamanager/partials/query.options.html
+++ b/datasources/clouderamanager/partials/query.options.html
@@ -1,0 +1,10 @@
+<section class="grafana-metric-options">
+	<div class="tight-form last">
+		<ul class="tight-form-list">
+			<li class="tight-form-item">
+				For TSQuery docs, go <a href="http://www.cloudera.com/content/cloudera/en/documentation/cloudera-manager/v4-latest/Cloudera-Manager-Diagnostics-Guide/cmdg_tsquery.html">here</a>
+			</li>
+		</ul>
+		<div class="clearfix"></div>
+	</div>
+</section>

--- a/datasources/clouderamanager/plugin.json
+++ b/datasources/clouderamanager/plugin.json
@@ -1,0 +1,16 @@
+{
+  "pluginType": "datasource",
+  "name": "Cloudera Manager",
+
+  "type": "clouderamanager",
+  "serviceName": "ClouderaManagerDatasource",
+
+  "module": "app/plugins/datasource/clouderamanager/datasource",
+
+  "partials": {
+    "config": "app/plugins/datasource/clouderamanager/partials/config.html"
+  },
+
+  "metrics": true,
+  "annotations": false
+}

--- a/datasources/clouderamanager/query_ctrl.js
+++ b/datasources/clouderamanager/query_ctrl.js
@@ -1,0 +1,16 @@
+define([
+  'angular',
+],
+function (angular) {
+  'use strict';
+
+  var module = angular.module('grafana.controllers');
+
+  module.controller('ClouderaManagerQueryCtrl', function($scope) {
+    $scope.init = function() {
+      if ($scope.target) {
+        $scope.target.target = $scope.target.target || '';
+      }
+    };
+  });
+});


### PR DESCRIPTION
Adds a minimal datasource for Cloudera Manager time series data.
The datasource will query CM with a particular "tsquery" statement and convert
the result to Grafana's expected format.

tsquery docs:
http://www.cloudera.com/content/cloudera/en/documentation/cloudera-manager/v4-latest/Cloudera-Manager-Diagnostics-Guide/cmdg_tsquery.html

API Docs:
http://cloudera.github.io/cm_api/apidocs/v10/