### PR TITLE
Updates for Cloudera Manager plugin

### DIFF
--- a/datasources/clouderamanager/README.md
+++ b/datasources/clouderamanager/README.md
@@ -1,0 +1,4 @@
+This plugin is for Grafana 2.6.x. For later versions, go to this repository:
+
+https://github.com/foursquare/datasource-plugin-clouderamanager
+

--- a/datasources/clouderamanager/datasource.js
+++ b/datasources/clouderamanager/datasource.js
@@ -2,13 +2,12 @@ define([
   'angular',
   'lodash',
   'jquery',
-  'config',
   'app/core/utils/datemath',
   'moment',
   './directives',
   './query_ctrl',
 ],
-function (angular, _, $, config, dateMath, moment) {
+function (angular, _, $, dateMath, moment) {
   'use strict';
 
   var module = angular.module('grafana.services');

--- a/datasources/clouderamanager/partials/config.html
+++ b/datasources/clouderamanager/partials/config.html
@@ -1,1 +1,19 @@
 <div ng-include="httpConfigPartialSrc"></div>
+
+<h5>Cloudera Manager Settings</h5>
+
+<div class="tight-form">
+	<ul class="tight-form-list">
+		<li class="tight-form-item" style="width: 80px">
+			API Version
+		</li>
+		<li>
+			<select class="tight-form-input input-medium" ng-model="current.jsonData.cmAPIVersion">
+				<option value="v4-5">v4-5</option>
+				<option value="v6-10">v6-10</option>
+				<option value="v11+">v11+</option>
+			</select>
+		</li>
+	</ul>
+	<div class="clearfix"></div>
+</div>


### PR DESCRIPTION
Updates the Cloudera Manager datasource plugin for Grafana 2.6.

Probably the last update since it is now available as a plugin at https://github.com/foursquare/datasource-plugin-clouderamanager.
