### PR TITLE
Atlas datasource plugin for Grafana 2.6

### DIFF
--- a/datasources/atlas-2.6/README.md
+++ b/datasources/atlas-2.6/README.md
@@ -1,0 +1,10 @@
+Atlas plugin for Grafana 2.6
+===============
+Plugin presents 2 ways of input an Atlas query: simple query builder UI and raw query input. You can switch input mode by `Switch raw Atlas query input` option in query row menu dropdown.
+
+
+Please pay attention to `atlasFormat` property in _plugins.json_ plugin configuration file. Default _json_ Atlas output format allow numeric values like _NaN_ will not get quoted, which can be the cause of problems on Grafana side. Atlas 1.5.0+ supports _std.json_ format. 
+
+More info about Atlas data formats [here](https://github.com/Netflix/atlas/wiki/Output-Formats).
+
+TODO: Add dynamic preloading of available metrics and dimensions(tags).

--- a/datasources/atlas-2.6/datasource.js
+++ b/datasources/atlas-2.6/datasource.js
@@ -1,0 +1,123 @@
+/*! grafana - v2.6.0 - 2015-12-14
+ * Copyright (c) 2015 Torkel Ödegaard; Licensed Apache-2.0 */
+
+define(["angular",
+        "lodash",
+        "app/core/utils/datemath",
+        "app/core/utils/kbn",
+        "./queryCtrl",
+        "./directives"
+    ],
+    function (angular, _, dateMath, kbn) {
+        "use strict";
+        var module = angular.module('grafana.services');
+        module.factory('AtlasDatasource', function ($q, backendSrv) {
+            function AtlasDatasource(datasource) {
+                this.name = datasource.name;
+                this.url = datasource.url;
+                this.type = datasource.type;
+                this.atlasFormat = datasource.meta.atlasFormat || 'std.json';
+                this.supportMetrics = true;
+
+                this.minimumInterval = datasource.minimumInterval || 1000;
+            }
+
+            AtlasDatasource.prototype.query = function (options) {
+                var queries = [];
+                options.targets.forEach(function (target, index) {
+                    if (target.hide || !(target.rawQuery || target.metric)) {
+                        return;
+                    }
+                    if (target.rawQueryInput) {
+                        if (!target.rawQuery) {
+                            return;
+                        }
+                        queries.push(target.rawQuery);
+                    } else {
+                        if (!target.metric) {
+                            return;
+                        }
+                        var queryParts = [];
+                        queryParts.push("name," + target.metric + ",:eq");
+                        if (target.tags) {
+                            var logicals = [];
+                            target.tags.forEach(function (tag, tagIndex) {
+                                queryParts.push(tag.name);
+                                queryParts.push(tag.value);
+                                queryParts.push(":" + tag.matcher);
+                                if ("not" === tag.notCondition) {
+                                    queryParts.push(":not");
+                                }
+                                logicals.push(":" + tag.logical);
+                            });
+                            queryParts = queryParts.concat(logicals);
+                        }
+                        if (target.aggregation) {
+                            queryParts.push(":" + target.aggregation);
+                        }
+                        if (target.groupBys && target.groupBys.length > 0) {
+                            queryParts.push("(");
+                            target.groupBys.forEach(function (groupBy, tagIndex) {
+                                queryParts.push(groupBy.name);
+                            });
+                            queryParts.push(")");
+                            queryParts.push(":by");
+                        }
+                        queries.push(queryParts.join(','));
+                    }
+                });
+                // Atlas can take multiple concatenated stack queries
+                var fullQuery = queries.join(',');
+
+                var interval = options.interval;
+
+                if (kbn.interval_to_ms(interval) < this.minimumInterval) {
+                    interval = kbn.secondsToHms(this.minimumInterval / 1000);
+                }
+
+                var params = {
+                    q: fullQuery,
+                    step: interval,
+                    s: new Date(options.range.from).getTime(),
+                    e: new Date(options.range.to).getTime(),
+                    format: this.atlasFormat
+                };
+
+                var httpOptions = {
+                    method: 'GET',
+                    url: this.url + '/api/v1/graph',
+                    params: params,
+                    inspect: {type: 'atlas'}
+                };
+
+                var deferred = $q.defer();
+                backendSrv.datasourceRequest(httpOptions).then(function (response) {
+                    if (!response.data) {
+                        var error = new Error("No data");
+                        deferred.reject(error);
+                    }
+                    deferred.resolve(convertToTimeseries(response.data))
+                });
+                return deferred.promise;
+            };
+
+            function convertToTimeseries(result) {
+                var timeseriesData = _.map(result.legend, function (legend, index) {
+                    var series = {target: legend, datapoints: []};
+                    var values = _.pluck(result.values, index);
+
+                    for (var i = 0; i < values.length; i++) {
+                        var value = values[i];
+                        var timestamp = result.start + (i * result.step);
+                        series.datapoints.push([value, timestamp]);
+                    }
+
+                    return series;
+                });
+
+                return {data: timeseriesData};
+            }
+
+            return AtlasDatasource;
+        });
+    });

--- a/datasources/atlas-2.6/directives.js
+++ b/datasources/atlas-2.6/directives.js
@@ -1,0 +1,23 @@
+define([
+  'angular'
+],
+function (angular) {
+  'use strict';
+
+  var module = angular.module('grafana.directives');
+
+  // Make sure the name match the directive call from panel_directive.js
+  // In this case <metric-query-editor-genericdatasource>
+  // Watch your casings!
+  module.directive('metricQueryEditorAtlas', function() {
+    return {
+      controller: 'AtlasTargetCtrl',
+      templateUrl: 'app/plugins/datasource/atlas/partials/query.editor.html'
+    };
+  });
+  module.directive('metricQueryOptionsAtlas', function() {
+    return {
+      templateUrl: 'app/plugins/datasource/atlas/partials/query.options.html'
+    };
+  });
+});

--- a/datasources/atlas-2.6/partials/config.html
+++ b/datasources/atlas-2.6/partials/config.html
@@ -1,0 +1,1 @@
+<div ng-include="httpConfigPartialSrc"></div>

--- a/datasources/atlas-2.6/partials/query.editor.html
+++ b/datasources/atlas-2.6/partials/query.editor.html
@@ -1,0 +1,180 @@
+<div class="tight-form" ng-controller="AtlasTargetCtrl">
+    <ul class="tight-form-list pull-right">
+        <li class="tight-form-item small" ng-show="target.datasource">
+            <em>{{target.datasource}}</em>
+        </li>
+        <li class="tight-form-item">
+            <div class="dropdown">
+                <a class="pointer dropdown-toggle" data-toggle="dropdown" tabindex="1">
+                    <i class="fa fa-bars"></i>
+                </a>
+                <ul class="dropdown-menu pull-right" role="menu">
+                    <li role="menuitem"><a tabindex="1" ng-click="toggleRawQuery()">Switch raw Atlas query input</a>
+                    </li>
+                    <li role="menuitem"><a tabindex="1" ng-click="duplicateDataQuery(target)">Duplicate</a></li>
+                    <li role="menuitem"><a tabindex="1" ng-click="moveDataQuery($index, $index-1)">Move up</a></li>
+                    <li role="menuitem"><a tabindex="1" ng-click="moveDataQuery($index, $index+1)">Move down</a></li>
+                </ul>
+            </div>
+        </li>
+
+        <li class="tight-form-item last">
+            <a class="pointer" tabindex="1" ng-click="removeDataQuery(target)">
+                <i class="fa fa-remove"></i>
+            </a>
+        </li>
+    </ul>
+
+    <ul class="tight-form-list">
+        <li class="tight-form-item" style="min-width: 15px; text-align: center">
+            {{target.refId}}
+        </li>
+        <li>
+            <a class="tight-form-item"
+               ng-click="target.hide = !target.hide; get_data();"
+               role="menuitem">
+                <i class="fa fa-eye"></i>
+            </a>
+        </li>
+    </ul>
+
+    <div class="tight-form" ng-if="target.rawQueryInput">
+        <ul class="tight-form-list" role="menu">
+            <li class="tight-form-item" style="width: 94px">
+                Query
+            </li>
+            <li>
+                <input type="text"
+                       class="input-xxlarge tight-form-input"
+                       ng-model="target.rawQuery"
+                       spellcheck='false'
+                       placeholder="Raw Atlas query expression"
+                       data-min-length=0 data-items=100
+                       ng-model-onblur
+                       ng-model-options="{ debounce: 1000 }"
+                       ng-change="get_data()">
+            </li>
+        </ul>
+    </div>
+    <div ng-if="!target.rawQueryInput">
+        <div class="tight-form">
+            <div class="tight-form-item" style="width: 94px">
+                Metric
+            </div>
+            <input type="text"
+                   class="input-xxlarge tight-form-input"
+                   ng-model="target.metric"
+                   ng-required="true"
+                   spellcheck='false'
+                   placeholder="metric name"
+                   data-min-length=0 data-items=100
+                   ng-model-onblur
+                   ng-model-options="{ debounce: 1000 }"
+                   ng-change="get_data()">
+        </div>
+        <div class="tight-form" style="display: inline-block">
+            <ul class="tight-form-list">
+                <li class="tight-form-item">
+                    <button class="btn btn-inverse" ng-click="addTag()" ng-hide="datasource.meta.mixed">
+                        <i class="fa fa-plus"></i>&nbsp;
+                        Dimension
+                    </button>
+                </li>
+            </ul>
+
+            <ul class="tight-form-list" ng-if="target.tags && target.tags.length > 0" style="display: inline-block">
+                <li ng-repeat="tag in target.tags" style="margin-bottom: 10px">
+
+                    <select id="logical"
+                            ng-model="tag.logical"
+                            ng-options="logical for logical in atlas.logical track by logical"
+                            ng-change="get_data()"
+                            ng-required="true"
+                            ng-default="tag.logical"
+                            style="width: 70px; margin-bottom: 0">
+                    </select>
+
+                    <input type="text"
+                           class="input-large tight-form-input"
+                           ng-model="tag.name"
+                           spellcheck='false'
+                           placeholder="name"
+                           data-min-length=0 data-items=50
+                           ng-model-onblur
+                           ng-change="get_data()">
+
+                    <select id="notCondition"
+                            ng-model="tag.notCondition"
+                            ng-options="notCondition for notCondition in atlas.notCondition track by notCondition"
+                            style="width: 70px; margin-bottom: 0"
+                            ng-required="true"
+                            ng-change="get_data()">
+                    </select>
+
+                    <select id="matchers"
+                            ng-model="tag.matcher"
+                            ng-options="matcher for matcher in atlas.matchers track by matcher"
+                            style="width: 70px; margin-bottom: 0"
+                            ng-change="get_data()">
+                    </select>
+
+                    <input type="text"
+                           class="input-large tight-form-input"
+                           ng-model="tag.value"
+                           spellcheck='false'
+                           placeholder="value"
+                           data-min-length=0 data-items=50
+                           ng-model-onblur
+                           ng-change="get_data()">
+                    <a class="pointer" tabindex="1" ng-click="removeTag(tag)">
+                        <i class="fa fa-remove"></i>
+                    </a>
+                </li>
+            </ul>
+        </div>
+        <div class="tight-form" style="display: flex">
+            <ul class="tight-form-list">
+                <li class="tight-form-item" style="width: 94px">
+                    Aggregation
+                </li>
+                <li class="tight-form-item">
+                    <select id="aggregationSelect"
+                            ng-model="target.aggregation"
+                            ng-options="aggregation for aggregation in atlas.aggregations track by aggregation"
+                            style="width: 80px; margin-bottom: 0"
+                            ng-change="get_data()"
+                            ng-required="true">
+                    </select>
+                </li>
+            </ul>
+        </div>
+        <div class="tight-form">
+            <ul class="tight-form-list">
+                <li class="tight-form-item">
+                    <button class="btn btn-inverse" ng-click="addGroupBy()">
+                        <i class="fa fa-plus"></i>&nbsp;
+                        Group By
+                    </button>
+                </li>
+            </ul>
+
+            <ul class="tight-form-list" ng-if="target.groupBys && target.groupBys.length > 0"
+                style="display: inline-block">
+                <li ng-repeat="groupBy in target.groupBys" class="tight-form-item" style="margin-bottom: 10px">
+                    <input type="text"
+                           ng-model="groupBy.name"
+                           spellcheck='false'
+                           placeholder="group by"
+                           data-min-length=0 data-items=50
+                           ng-size="groupBy.name.length"
+                           ng-model-onblur
+                           ng-change="get_data()">
+                    <a class="pointer" tabindex="1" ng-click="removeGroupBy(groupBy)">
+                        <i class="fa fa-remove"></i>
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </div>
+    <div class="clearfix"></div>
+</div>

--- a/datasources/atlas-2.6/partials/query.editor.html
+++ b/datasources/atlas-2.6/partials/query.editor.html
@@ -72,6 +72,20 @@
                    ng-model-options="{ debounce: 1000 }"
                    ng-change="get_data()">
         </div>
+        <div class="tight-form">
+            <div class="tight-form-item" style="width: 94px">
+                Alias
+            </div>
+            <input type="text"
+                   class="input-xlarge tight-form-input"
+                   ng-model="target.alias"
+                   spellcheck='false'
+                   placeholder="metric alias"
+                   data-min-length=0 data-items=100
+                   ng-model-onblur
+                   ng-model-options="{ debounce: 1000 }"
+                   ng-change="get_data()">
+        </div>
         <div class="tight-form" style="display: inline-block">
             <ul class="tight-form-list">
                 <li class="tight-form-item">

--- a/datasources/atlas-2.6/partials/query.options.html
+++ b/datasources/atlas-2.6/partials/query.options.html
@@ -1,0 +1,21 @@
+<section class="grafana-metric-options" ng-controller="AtlasTargetCtrl">
+    <div class="grafana-target">
+        <div class="grafana-target-inner">
+            <ul class="grafana-segment-list">
+                <li class="grafana-target-segment">
+                    <a href="https://github.com/Netflix/atlas/wiki/Examples" target="_blank"
+                       bs-tooltip="'Click to show Atlas Stack Language examples'" data-placement="bottom">
+                        ASL examples
+                    </a>
+                </li>
+                <li class="grafana-target-segment">
+                    <a href="https://github.com/Netflix/atlas/wiki/Stack-Language-Reference" target="_blank"
+                       bs-tooltip="'Click to show Atlas Stack Language reference'" data-placement="bottom">
+                        ASL reference
+                    </a>
+                </li>
+            </ul>
+            <div class="clearfix"></div>
+        </div>
+    </div>
+</section>

--- a/datasources/atlas-2.6/plugin.json
+++ b/datasources/atlas-2.6/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "Atlas",
+  "type": "atlas",
+  "pluginType": "datasource",
+  "serviceName": "AtlasDatasource",
+  "atlasFormat": "std.json",
+
+  "module": "app/plugins/datasource/atlas/datasource",
+
+  "partials": {
+    "config": "app/plugins/datasource/atlas/partials/config.html"
+  },
+
+  "metrics": true
+}

--- a/datasources/atlas-2.6/queryCtrl.js
+++ b/datasources/atlas-2.6/queryCtrl.js
@@ -1,0 +1,95 @@
+define([
+        'angular',
+        'lodash'
+    ],
+    function (angular, _) {
+        'use strict';
+
+        var module = angular.module('grafana.controllers');
+
+        module.controller('AtlasTargetCtrl', function ($scope) {
+            $scope.init = function () {
+                $scope.atlas = {};
+
+                $scope.atlas.aggregations = [
+                    "sum",
+                    "avg",
+                    "count"
+                ];
+
+                $scope.atlas.logical = [
+                    "and",
+                    "or"
+                ];
+
+                $scope.atlas.notCondition = [
+                    " ",
+                    "not"
+                ];
+
+                $scope.atlas.matchers = [
+                    "eq",
+                    "ge",
+                    "gt",
+                    "le",
+                    "lt",
+                    "has",
+                    "in"
+                ];
+            };
+
+            $scope.moveMetricQuery = function (fromIndex, toIndex) {
+                _.move($scope.panel.targets, fromIndex, toIndex);
+                $scope.get_data();
+            };
+
+            $scope.duplicate = function () {
+                var clone = angular.copy($scope.target);
+                $scope.panel.targets.push(clone);
+                $scope.get_data();
+            };
+
+            $scope.toggleRawQuery = function () {
+                $scope.target.rawQueryInput = !$scope.target.rawQueryInput;
+                $scope.get_data();
+            };
+
+            $scope.removeTag = function (tag) {
+                if ($scope.target.tags) {
+                    $scope.target.tags.splice($scope.target.tags.indexOf(tag), 1);
+                    $scope.get_data();
+                }
+            };
+
+            $scope.addTag = function () {
+                if (!$scope.target.tags) {
+                    $scope.target.tags = [];
+                }
+                $scope.target.tags.push({
+                    name: null,
+                    value: null,
+                    notCondition: $scope.atlas.notCondition[0],
+                    logical: $scope.atlas.logical[0],
+                    matcher: $scope.atlas.matchers[0]
+                });
+            };
+
+            $scope.removeGroupBy = function (groupBy) {
+                if ($scope.target.groupBys) {
+                    $scope.target.groupBys.splice($scope.target.groupBys.indexOf(groupBy), 1);
+                    $scope.get_data();
+                }
+            };
+
+            $scope.addGroupBy = function () {
+                if (!$scope.target.groupBys) {
+                    $scope.target.groupBys = [];
+                }
+                $scope.target.groupBys.push({});
+            };
+
+
+            $scope.init();
+        });
+
+    });


### PR DESCRIPTION
Atlas plugin for Grafana 2.6 is based on [older Atlas plugin implementation](https://github.com/grafana/grafana-plugins/tree/master/datasources/atlas).
Plugin presents 2 ways of input an Atlas query: simple query builder UI and raw query input.
Atlas response data format is configurable in _plugins.json_ file. More info in _README.md_ file.

This pull request is a part of Upwork.com contribution to Grafana project.